### PR TITLE
Prevent Discord from crashing when right-clicking a user - Part 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,11 @@ module.exports = class CopyAvatarURL extends Plugin {
 
         if (document.querySelector('#user-context')) {
           const instance = getOwnerInstance(document.querySelector('#user-context'));
-          ({ user } = instance._reactInternals.return.memoizedProps);
+          user = (instance?._reactInternals || instance?._reactInternalFiber)?.return?.memoizedProps?.user;
+        }
+
+        if (!user) {
+          return args;
         }
 
         const copyAvatarUrlItem = React.createElement(Menu.MenuItem, {


### PR DESCRIPTION
To give you some background info, the latest Canary build at this time of writing (Build 72381) has since reverted the client from React 17 - this sadly causes Discord to crash once again as `_reactInternals` is now `_reactInternalFiber` again. This pull request provides a complete fix by simply checking if the owner instance of the user context menu posses one of the two mentioned.